### PR TITLE
Fixed fileSave function in http.factory

### DIFF
--- a/common/factories/http.factory.js
+++ b/common/factories/http.factory.js
@@ -162,7 +162,6 @@ app.factory('http', ['$http', 'config', '$rootScope', 'loginFactory', '$q', func
 
       fileSave: function (url, data, successFunc, errFunc) {
          var headers = data.headers || {};
-         url = _getUrl(url);
          headers['Content-type'] = 'application/octet-stream';
          headers.preview = (data.mimetype === 'application/pdf') ? 'true' : 'false';
          $http({


### PR DESCRIPTION
Fix of http.fileSave function required on cad for use with acl 1.0.0. Please check other projects